### PR TITLE
Update pkg bash completion

### DIFF
--- a/pkg
+++ b/pkg
@@ -1,31 +1,49 @@
 # OpenIndiana pkg(5) completion                             -*- shell-script -*-
 # ------------------------------------------------------------------------------
-# Aurelien Larcher <aurelien@openindiana.org>
+# Copyright (c) 2017, Aurelien Larcher <aurelien@openindiana.org>
+# Copyright (c) 2018, Michal Nowak <mnowak@startmail.com>
 
 # Bash-completion does not handle custom wordbreaks so comma-separated values
 # cannot be implemented without this.
 COMP_WORDBREAKS="${COMP_WORDBREAKS//,},"
+
+_get_installed_packages()
+{
+  # XXX: Lists only last part of package's FMRI, path walker is warranted
+  COMPREPLY=( $(compgen -W "$(pkg list -H $* | awk '{print $1}' | awk -F/ '{print $NF}')" -- "${cur}") )
+}
+
+_get_values()
+{
+  local command="$1"
+  COMPREPLY=( $(compgen -W "$(pkg $command -H | awk '{print $1}')" -- "${cur}") )
+}
+
+_get_alternative_output_format()
+{
+  COMPREPLY=( $(compgen -W "tsv json json-formatted" -- "${cur}") )
+}
 
 _pkg5()
 {
   local cur prev words cword
   _init_completion || return
 
-  local cmds="list search info contents update install uninstall exact-install history
+  local cmds="list search info contents update install uninstall exact-install history apply-hot-fix
               verify fix
               publisher set-publisher unset-publisher
               mediator set-mediator unset-mediator facet change-facet variant change-variant
               avoid unavoid freeze unfreeze
               refresh rebuild-index purge-history
               property set-property add-property-value unset-property remove-property-value
-              image-create dehydrate rehydrate help"
+              image-create dehydrate rehydrate help update-format version"
   local cmd_opts=""
 
   # Lookup for command
   local special i
   for (( i=1; i < $cword; i++ ))
   do
-    if [[ ${words[i]} == @(list|search|info|contents|update|@(|un|exact-)install|history|verify|fix|@(|set-|unset-)publisheri|@(|set-|unset-)mediator|@(|change-)facet|@(|change-)variant|@(|un)avoid|@(|un)freeze|refresh|rebuild-index|purge-history|@(|set-|unset-)property|@(add-|remove-)property-value|image-create|@(de|re)hydrate|help) ]]
+    if [[ ${words[i]} == @(list|search|info|contents|update|update-format|version|@(|un|exact-)install|history|verify|fix|apply-hot-fix|@(|set-|unset-)publisher|@(|set-|unset-)mediator|@(|change-)facet|@(|change-)variant|@(|un)avoid|@(|un)freeze|refresh|rebuild-index|purge-history|@(|set-|unset-)property|@(add-|remove-)property-value|image-create|@(de|re)hydrate|help) ]]
     then
       special=${words[i]}
       break
@@ -38,8 +56,8 @@ _pkg5()
     local pkg_opts="-? --help -R"
     if [[ "${prev}" == "-R" ]]
     then
-      # List BE mountpoints
-      COMPREPLY=( $(compgen -W "$(beadm list -H | cut -f 4 -d ';')" -- "${cur}") )
+      # Operate on the image rooted at dir
+      _cd
       return
     fi
   else
@@ -84,6 +102,10 @@ _pkg5()
       list)
         cmd_opts="-H -a -f -n -q -s -u -v -g --no-refresh"
         ;;
+      mediator)
+        # [-aH] [-F format] [mediator ...]
+        cmd_opts="-a -H -F"
+        ;;
       facet)
         cmd_opts="-a -H -F"
         ;;
@@ -98,10 +120,10 @@ _pkg5()
         ;;
       search)
         cmd_opts="-H -I -a -f -l -p -r -o -s"
-        #XXX: complete the list of attributes
+        # XXX: complete the list of attributes per pkg(1) and pkg(5)
         local pkg_attributes="pkg.fmri pkg.name pkg.human-version info.classification pkg.description
                               pkg.summary pkg.renamed pkg.obsolete" 
-        #XXX: queries are not implemented
+        # XXX: queries are not implemented
         case ${cur} in
           '"')
             local realcur="${cur##\"}"
@@ -192,6 +214,33 @@ _pkg5()
     fi
   else
     COMPREPLY=( $(compgen -W "${cmd_opts}" -- "${cur}") )
+  fi
+
+  if [[ "${cur}" != -* ]]
+  then
+    case ${special} in
+    contents|list|freeze|unfreeze|update)
+      _get_installed_packages
+      ;;
+    info)
+      [[ ${prev} == "-r" ]] && _get_installed_packages -a || _get_installed_packages
+      ;;
+    install|exact-install)
+      _get_installed_packages -a
+      ;;
+    publisher|refresh)
+      _get_values publisher
+      ;;
+    property)
+      _get_values ${special}
+      ;;
+    mediator|variant|facet)
+      [[ ${prev} == "-F" ]] && _get_alternative_output_format || _get_values ${special}
+      ;;
+    dehydrate|rehydrate)
+      [[ ${prev} == "-p" ]] && _get_values publisher
+      ;;
+    esac
   fi
 } &&
   complete -F _pkg5 +o default pkg


### PR DESCRIPTION
* Add `apply-hot-fix` command (added in OI 2018.10)
* `-R` option should look for a root dir with an image
* Add options for the `mediator` command
* Complete packages, publishers and properties of various commands

No progress with `search` command queries.