### PR TITLE
beadm: Remove colon from set of word separators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# OpenIndiana completions
+
+This is a set of Bash completions specific to illumos distributions like OpenIndiana.
+
+We cover illumos-specific commands not found in the [bash-completion](https://github.com/scop/bash-completion) project.
+
+OpenIndiana users are expected to consume this project via the `utility/bash-completion`
+[component](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/shell/bash-completion)
+as it agregates stable version of openindiana-completions.

--- a/beadm
+++ b/beadm
@@ -1,11 +1,15 @@
 # OpenIndiana beadm(1M) completion                          -*- shell-script -*-
 # ------------------------------------------------------------------------------
 # Copyright (c) 2017, Aurelien Larcher <aurelien@openindiana.org>
-# Copyright (c) 2018, Michal Nowak <mnowak@startmail.com>
+# Copyright (c) 2019, Michal Nowak <mnowak@startmail.com>
 
 # Bash-completion does not handle custom wordbreaks so comma-separated values
 # cannot be implemented without this.
 COMP_WORDBREAKS="${COMP_WORDBREAKS//,},"
+
+# BE name may contain ':', e.g. to delimit date. It needs to be removed from
+# set of word separators, otherwise we are stuck half-way in BE name completion.
+COMP_WORDBREAKS="${COMP_WORDBREAKS//:/}"
 
 _beadm()
 {


### PR DESCRIPTION
`beadm list` started failing after introduction of BE names like `openindiana-2019:03:17`.