### PR TITLE
11519 `beadm activate` bash completion should complete all but "R"-marked entries

### DIFF
--- a/beadm
+++ b/beadm
@@ -110,7 +110,8 @@ _beadm()
                   local be_and_snapshots=()
                   case "${special}" in
                     activate)
-                      be_and_snapshots=( $(beadm list -H | nawk -F ';' '$3 !~ "N"  {print $1}') )
+                      # Activate only BEs not already set active on reboot ('R')
+                      be_and_snapshots=( $(beadm list -H | nawk -F ';' '$3 !~ "R"  {print $1}') )
                       ;;
                     destroy)
                       be_and_snapshots=( $(beadm list -H -a | nawk -F ';' '$2 ~ "@" {print $2}; $3 !~ "N" {print $1}' | sort | uniq) )
@@ -122,7 +123,8 @@ _beadm()
                       be_and_snapshots=( $(beadm list -H | nawk -F ';' '$3 !~ "N" && $4 != "" {print $1}') )
                       ;;
                     rename)
-                      be_and_snapshots=( $(beadm list -H | nawk -F ';' '$3 !~ "R"  {print $1}') )
+                      # Rename all but currently/now active ('N') BEs
+                      be_and_snapshots=( $(beadm list -H | nawk -F ';' '$3 !~ "N"  {print $1}') )
                       ;;
                     rollback)
                       # list BEs and snapshots


### PR DESCRIPTION
Plus a similar fix for for the `rename` command.